### PR TITLE
Fix stack level too deep

### DIFF
--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -20,14 +20,16 @@ MY_APPLICATION_NAME = "TweetSpace_Ingesup"
   
   private
   def self.client
-    Grackle::Client.new(:auth=>{
-      :type=>:oauth,
-      :consumer_key=>'Gzm6I93ZW8sR2LMbCpod7HOnf',
-      :consumer_secret=>'nIOyQmzYq2wnwYMvaNHjhNutjqXnD2uTNFbvsph5KpsqxdHtJ7',
-      :token=>"440215471-ViSDu9rTcC9OzWKmgq5cJRryALIOaJdxh28j3N0g",
-      :token_secret=>"xOkniXd5Pvg0QJLXxmtWbIou5wmq2aOJRZUhWy7mVMIXA"
-    })
-	client.ssl = true
+    Grackle::Client.new(
+      ssl: true,
+      auth: {
+        type: :oauth,
+        claonsumer_key: 'Gzm6I93ZW8sR2LMbCpod7HOnf',
+        consumer_secret: 'nIOyQmzYq2wnwYMvaNHjhNutjqXnD2uTNFbvsph5KpsqxdHtJ7',
+        token: "440215471-ViSDu9rTcC9OzWKmgq5cJRryALIOaJdxh28j3N0g",
+        token_secret: "xOkniXd5Pvg0QJLXxmtWbIou5wmq2aOJRZUhWy7mVMIXA",
+      }
+    )
   end
 end
 

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -5,15 +5,16 @@ class Tweet < ActiveRecord::Base
 MY_APPLICATION_NAME = "TweetSpace_Ingesup"
   
   def self.get_latest
-  	puts("Hello"); / Est affiché /
+  	puts("Hello"); # Est affiché
+
   	tweets = client.user_timeline("gem")
-    /tweets = client.statuses.user_timeline? :screen_name => MY_APPLICATION_NAME # hit the API/
-    puts("Hello3"); / N'est pas affiché /
+    # tweets = client.statuses.user_timeline? :screen_name => MY_APPLICATION_NAME # hit the API
+    puts("Hello3"); # N'est pas affiché
     tweets.each do |t|
       created = DateTime.parse(t.created_at)
       unless Tweet.exists?(["created=?", created])
         Tweet.create({:content => t.text, :created => created })
-       end
+      end
     end
     
   end


### PR DESCRIPTION
Dans `self.client`, l'appel à `client.ssl = true`  refaisait appel à `self.client` et ainsi de suite.

J'ai aussi corrigé les commentaires que vous écriviez entre `//` : cette syntaxe définit une expression régulière :  

```ruby
/est une expression régulière/
# est un commentaire
```

Sinon pourquoi vous n'utilisez pas la gem Twitter comme j'ai indiqué dans le cours ?
https://github.com/sferik/twitter

Elle est plus documentée que Grackle, qui n'est plus maintenue depuis 4 ans et je doute que vous puissiez arriver à vos fins avec.

